### PR TITLE
fix: use cleanUrls in firebase config

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,7 @@
 {
   "hosting": {
     "public": "out",
+    "cleanUrls": true,
     "redirects": [
       {
         "source": "/main/index.html",

--- a/justfile
+++ b/justfile
@@ -9,3 +9,8 @@ build:
 # run dev env with livereload, for local editing
 dev:
     pnpm dev
+
+# run dev env via firebase, for a more prod-like local editing experience
+firebase-dev:
+    @just build
+    firebase emulators:start


### PR DESCRIPTION
Sets `cleanUrls=true` in the Firebase config [0], to fix how subpage navigation works on the hosted site. I'm not stoked that we need to perform this kind of URL rewriting at the hosting layer; I'd prefer that the build step emitted a properly structured static docroot.

Refs #8.

[0] https://firebase.google.com/docs/hosting/full-config#control_html_extensions