### PR TITLE
feat: remove hardcoded versions in chain-upgrade docs

### DIFF
--- a/pages/node/pd/chain-upgrade.mdx
+++ b/pages/node/pd/chain-upgrade.mdx
@@ -1,5 +1,3 @@
-import {PENUMBRA_VERSION} from '../../../penumbra_versions.js';
-
 # Performing a chain upgrade
 
 When consensus-breaking changes are made to the Penumbra protocol,
@@ -29,7 +27,7 @@ Consider performing a backup as a preliminary step during the downtime,
 so that your node state is recoverable.
 
 1. Stop both `pd` and `cometbft`. Depending on how you run Penumbra, this could mean `sudo systemctl stop penumbra cometbft`.
-2. Download the latest version of `pd` and install it. Run `pd --version` and confirm you see "{PENUMBRA_VERSION}" before proceeding.
+2. Download the latest version of `pd` and install it. Run `pd --version` and confirm you see the correct version.
 3. Optionally, use `pd export` to create a snapshot of the `pd` state.
 4. Apply the migration with `pd migrate --home PD_HOME --comet-home COMETBFT_HOME`.  If using the default home locations (from `pd network join`), you can omit the paths and just run `pd migrate`.
 

--- a/pages/node/pd/install.mdx
+++ b/pages/node/pd/install.mdx
@@ -1,4 +1,4 @@
-import { PENUMBRA_VERSION, COMETBFT_VERSION } from '../../../penumbra_versions.js';
+import { COMETBFT_VERSION } from '../../../penumbra_versions.js';
 
 # Installing pd
 There are many ways to configure and run Penumbra. The easiest is to download
@@ -21,7 +21,6 @@ sudo mv pd-x86_64-unknown-linux-gnu/pd /usr/local/bin/
 # confirm the pd binary is installed by running:
 pd --version
 ```
-Make sure the version that's installed is at least <code>{PENUMBRA_VERSION}</code>.
 There's also a one-liner install script available on the release page, which will install `pd` to `$HOME/.cargo/bin/`.
 
 ### Installing CometBFT

--- a/penumbra_versions.js
+++ b/penumbra_versions.js
@@ -3,5 +3,5 @@
 // works in normal prose, but fails in backticked-codeblocks. There's some discussion
 // about how to do this better in https://github.com/orgs/mdx-js/discussions/2288.
 
-export const PENUMBRA_VERSION = 'v0.79.2';
+export const PENUMBRA_VERSION = 'v0.79.3';
 export const COMETBFT_VERSION = 'v0.37.9';


### PR DESCRIPTION
Back when the guide was managed in the Penumbra protocol repo [0], the version strings in the docs were automatically bumped in line with the source code changes. Since breaking the guide out into a separate repo, we no longer have the convenience of those automatic updates, so the guide versions will necessarily lag behind. Let's remove the hardcoded version strings from crucial reference pages like the chain-upgrade docs, leaning on node operators to choose the correct version for a given upgrade.

[0] https://github.com/penumbra-zone/penumbra