### PR TITLE
build: add nodejs dep to flake env

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
             buildInputs = [ 
                 firebase-tools
                 just
+                nodejs_20
                 pnpm
             ];
           };


### PR DESCRIPTION
This was always required, but was omitted in the flake env, causing `node` from system PATH to be used. It's more explicit to track a compatible version, so that `just dev` works out of the box for nix users.