### PR TITLE
chore: update pd & cometbft versions

### DIFF
--- a/pages/node/pd/install.mdx
+++ b/pages/node/pd/install.mdx
@@ -26,7 +26,8 @@ There's also a one-liner install script available on the release page, which wil
 ### Installing CometBFT
 
 You'll need to have [CometBFT installed](https://docs.cometbft.com/v0.37/guides/install) on your system to join your node to the network.
-You must use a compatible version of CometBFT. Any version in the `v0.37.x` series will work, such as <code>{COMETBFT_VERSION}</code>,
+You must use a `v0.37.x` version of CometBFT, at least <code>{COMETBFT_VERSION}</code>,
 which you can download [from the CometBFT releases page](https://github.com/cometbft/cometbft/releases/).
+Penumbra is not yet compatible with CometBFT `v0.38.x` or `v1.x`.
 If you prefer to compile from source instead, make sure you are compiling the correct version by checking out its tag
 in the CometBFT repo before building.

--- a/penumbra_versions.js
+++ b/penumbra_versions.js
@@ -3,5 +3,5 @@
 // works in normal prose, but fails in backticked-codeblocks. There's some discussion
 // about how to do this better in https://github.com/orgs/mdx-js/discussions/2288.
 
-export const PENUMBRA_VERSION = 'v0.79.3';
-export const COMETBFT_VERSION = 'v0.37.9';
+export const PENUMBRA_VERSION = 'v1.0.1';
+export const COMETBFT_VERSION = 'v0.37.15';


### PR DESCRIPTION
The cometbft version bump is updated to include 0.37.15, to include patches to security issues. See details in [0].

[0] https://github.com/cometbft/cometbft/blob/v0.37.15/CHANGELOG.md#v03715