### PR TITLE
lint: fix broken links throughout

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: lint
+on:
+  pull_request:
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: buildjet-16vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: install nix
+        uses: nixbuild/nix-quick-install-action@v28
+
+      - name: setup nix cache
+        uses: nix-community/cache-nix-action@v5
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          backend: buildjet
+
+      # Run the linter target
+      - name: lint
+        run: nix develop --command just lint

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,28 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://(x|twitter).com"
+    },
+    {
+      "pattern": "^http://localhost"
+    },
+    {
+      "pattern": "^http://127.0.0.1"
+    },
+    {
+      "pattern": "images/pvf-linear.png"
+    },
+    {
+      "pattern": "images/governance-light.png"
+    },
+    {
+      "pattern": "https://accounts.hetzner.com"
+    }
+  ],
+  "replacementPatterns": [
+    {
+      "pattern": "^/images/(?<filename>.*)",
+      "replacement": "../public/images/$<filename>"
+    }
+  ]
+}

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1721562059,
-        "narHash": "sha256-Tybxt65eyOARf285hMHIJ2uul8SULjFZbT9ZaEeUnP8=",
+        "lastModified": 1742751704,
+        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68c9ed8bbed9dfce253cc91560bf9043297ef2fe",
+        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 # in flake.nix
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs = { self, nixpkgs, flake-utils }:

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ dev:
 
 # run linters, checking for valid links
 lint:
-  fd -t f -e md -e mdx -X markdown-link-check
+  fd -t f -e md -e mdx -X markdown-link-check --config .markdown-link-check.json
 
 # run dev env via firebase, for a more prod-like local editing experience
 firebase-dev:

--- a/pages/dev/build.mdx
+++ b/pages/dev/build.mdx
@@ -9,7 +9,7 @@ consider using [WSL] instead.
 
 This page aims to describe the steps necessary to work on Penumbra when
 settings up the build environment manually, without using [Nix].
-If you want an easy-to-use setup, see the docs on [developer environments](./dev-env.md).
+If you want an easy-to-use setup, see the docs on [developer environments](./dev-env.mdx).
 
 ### Installing the Rust toolchain
 

--- a/pages/dev/dev-env.mdx
+++ b/pages/dev/dev-env.mdx
@@ -4,7 +4,7 @@ To get started working on Penumbra, you'll need a few dependencies on your works
 Running tests and local services is more involved. The project uses [Nix] to automate
 the creation of developer environments with suitable tooling. If you'd prefer not to use
 Nix, and instead configure your environment manually, see the docs on
-[compiling from source](./build.md).
+[compiling from source](./build.mdx).
 
 ## Install OS-level packages
 You'll need `git` and `git-lfs` to clone the Penumbra protocol repository.

--- a/pages/dev/devnet-quickstart.md
+++ b/pages/dev/devnet-quickstart.md
@@ -1,6 +1,6 @@
 # Devnet quickstart
 
-This page assumes you've set up a [Penumbra developer environment](./dev-env.md),
+This page assumes you've set up a [Penumbra developer environment](./dev-env.mdx),
 as it references several commands like `cometbft` in order to work.
 It describes how to run a Penumbra fullnode on your local workstation, for building
 and testing Penumbra and related services.

--- a/pages/dev/docs.md
+++ b/pages/dev/docs.md
@@ -18,7 +18,7 @@ mdbook serve
 The [Rust API docs][rustdoc] are maintained in the [protocol repo], and
 can be built with `./deployments/scripts/rust-docs`. Notably, the rust docs
 require the use of a nightly rust toolchain, which isn't currently provided via the
-[dev env](dev-env.md). You should install the nightly toolchain on your host machine,
+[dev env](dev-env.mdx). You should install the nightly toolchain on your host machine,
 if you need to build the rustdocs locally.
 
 The landing page, the top-level `index.html`, is handled as a special case.

--- a/pages/dev/ibc.md
+++ b/pages/dev/ibc.md
@@ -51,7 +51,7 @@ You can view account history for the shared Osmosis testnet account here:
 Change the address at the end of the URL to your account to confirm that your test transfer worked.
 
 ## Updating Hermes config for a new testnet
-See the [relayer config guide](../node/relayer/hermes.md) for up to date information.
+See the [relayer config guide](../relayers.md) for up to date information.
 
 Use the [IBC user docs](../pcli/transaction.md#ibc-withdrawals) to make a test transaction,
 to ensure that relaying is working. In the future, we should consider posting the newly created

--- a/pages/dev/rpc.md
+++ b/pages/dev/rpc.md
@@ -1,7 +1,7 @@
 # Working with gRPC for Penumbra
 
 The Penumbra [`pd`](../node/pd.md) application exposes a [gRPC] service for integration
-with other tools, such as [`pcli`](../pcli.md) or the [web extension](../web.md).
+with other tools, such as [`pcli`](../pcli.md) or the [web extension](../web.mdx).
 A solid understanding of how the gRPC methods work is helpful when
 building software that interoperates with Penumbra.
 

--- a/pages/dev/testnet.md
+++ b/pages/dev/testnet.md
@@ -34,14 +34,14 @@ curl -O https://artifacts.plinfra.net/penumbra-testnet-phobos-2/penumbra-node-ar
 tar -xzf penumbra-node-archive-latest.tar.gz -C ~/.penumbra/network_data/node0/
 ```
 
-After that, if you've set up the [Penumbra developer environment](./dev-env.md),
+After that, if you've set up the [Penumbra developer environment](./dev-env.mdx),
 you can run a fullnode locally via:
 
 ```shell
 just dev
 ```
 
-For a more persistent setup, consult the [tutorial on running a node](../node/pd/running-node.md).
+For a more persistent setup, consult the [tutorial on running a node](../node/pd/running-node.mdx).
 
 ## Running `pcli`
 

--- a/pages/dex.mdx
+++ b/pages/dex.mdx
@@ -11,7 +11,7 @@ The Penumbra DEX features a batched swap/intent system and enables fine-grained 
 The incoming order flow of swap intents are batched together by trading pair and executed at the end of each block. The batching of swap intents means that in Penumbra, there is no intra-block ordering of swap intents that can be manipulated by traders. Trades get executed approximately every 5 seconds - Penumbra's block time.
 
 <picture>
-  <img src="./images/dex-batch-execution.png" />
+  <img src="/images/dex-batch-execution.png" />
 </picture>
 
 Each block, the Penumbra protocol:
@@ -33,24 +33,24 @@ One important feature of the `SwapClaim` transaction is that it can be *automati
 The phased two-block execution of the `Swap` and `SwapClaim` transactions is illustrated below:
 
 <picture>
-  <img src="./images/dex-swap-claim.png" />
+  <img src="/images/dex-swap-claim.png" />
 </picture>
 
 ### Concentrated Liquidity Positions
 
 *Market makers* are users who provide liquidity by agreeing to buy and sell a specific trading pair at a price they specify. They do this by creating a *liquidity position* in Penumbra.
 
-Penumbra's DEX supports concentrated [liquidity positions](/dex/lp). Each liquidity position in Penumbra is essentially a constant-sum individual [Automated Market Maker (AMM)](https://www.gemini.com/cryptopedia/amm-what-are-automated-market-makers#section-automated-market-maker-variations). Fees are set on a per-position basis, instead of fee tiers. This enables market forces to set fees.
+Penumbra's DEX supports concentrated [liquidity positions](./dex/lp.mdx). Each liquidity position in Penumbra is essentially a constant-sum individual [Automated Market Maker (AMM)](https://www.gemini.com/cryptopedia/amm-what-are-automated-market-makers#section-automated-market-maker-variations). Fees are set on a per-position basis, instead of fee tiers. This enables market forces to set fees.
 
 By creating an arbitrary number of these concentrated liquidity positions, market makers can approximate any trading function:
 
 <picture>
-  <img src="./images/dex-concentrated-liquidity.png" />
+  <img src="/images/dex-concentrated-liquidity.png" />
 </picture>
 
 This enables fine-grained control over liquidity provisioning. Active market makers can adjust prices as often as once per block.
 
-The positions themselves are public, but anonymous. For further details on liquidity positions, see the [Providing Liquidity](/dex/lp) page.
+The positions themselves are public, but anonymous. For further details on liquidity positions, see the [Providing Liquidity](./dex/lp.mdx) page.
 
 ### DEX Execution and Optimal Routing
 
@@ -59,7 +59,7 @@ Penumbra's DEX automatically finds the *best* trading path across all available 
 We call the collection of all liquidity positions the *liquidity graph*, as it can be thought of as a graph of nodes and edges, and the Penumbra DEX engine traverses the graph to find the best path for your trade.
 
 <picture>
-  <img src="./images/dex-optimal-routing.png" />
+  <img src="/images/dex-optimal-routing.png" />
 </picture>
 
 Each block, the DEX engine executes in four steps:

--- a/pages/dex/lp.mdx
+++ b/pages/dex/lp.mdx
@@ -9,7 +9,7 @@ import { Callout, Steps } from 'nextra/components'
 Penumbra's DEX is built around order-book-style concentrated liquidity.
 Liquidity positions are constant-sum AMMs, offering to trade between assets at a
 fixed price.  Each position is its own independent AMM with its own fee tier,
-and as described in the [DEX chapter](./dex.mdx), the DEX engine indexes active
+and as described in the [DEX chapter](../dex.mdx), the DEX engine indexes active
 liquidity positions and sorts them by price, then traverses the liquidity graph
 to optimally fill trades. 
 
@@ -176,7 +176,7 @@ Do you want to open those liquidity positions on-chain? [y/n]
 
 The portfolio value function of this strategy (not accounting for fees) can be visualized as follows:
 <picture>
-  <img src="./images/pvf-linear.png" />
+  <img src="/images/pvf-linear.png" />
 </picture>
 
 The x-axis shows the price of `UM` in terms of `USDC`, and the y-axis shows the
@@ -220,7 +220,7 @@ This section is incomplete. You can help by expanding it!
 </Callout>
 
 Programmatic access to a wallet's private state and transaction construction is
-possible using `pclientd`. See the [`pclientd` section](./node/pclientd.md) of
+possible using `pclientd`. See the [`pclientd` section](../node/pclientd.md) of
 the guide for details. This allows client software to work only with a local
 GRPC endpoint and not have to worry about any Penumbra-specific cryptography or
 ZK proving.

--- a/pages/frontend/minifront.md
+++ b/pages/frontend/minifront.md
@@ -91,7 +91,7 @@ pnpm dev
 
 ## Frontend embedded in fullnode
 
-If you're already [running a fullnode](./running-node.md), then you don't need to do anything else:
+If you're already [running a fullnode](../node/pd/running-node.mdx), then you don't need to do anything else:
 a bundled version of the frontend code is available at `https://<YOUR_NODE_URL>/app`. Simply navigate
 to that site after installing [Prax], and authorize the web extension to connect to it.
 

--- a/pages/gov.mdx
+++ b/pages/gov.mdx
@@ -55,7 +55,7 @@ Votes cannot be changed after they are cast.
 At the end of the voting period, a proposal passes, fails, or is slashed. The proposal can also be withdrawn before the voting period ends. A withdrawn proposal can still be slashed. This diagram illustrates the proposal lifecycle:
 
 <picture>
-  <img src="./images/governance-diagram.png" />
+  <img src="/images/governance-diagram.png" />
 </picture>
 
 Non-emergency proposals pass as long as they achieve:

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -10,10 +10,10 @@ stake, swap, or marketmake without broadcasting their personal information to
 the world.  Unlike a transparent chain, where all information is public,
 Penumbra is end-to-end encrypted, and transactions are shielded by default.
 
-<Callout type="info" emoji="ℹ️">Get up and running quickly with [our interactive guide](/quickstart) to basic Penumbra actions!</Callout>
+<Callout type="info" emoji="ℹ️">Get up and running quickly with [our interactive guide](./quickstart.mdx) to basic Penumbra actions!</Callout>
 <br></br>
 
 <picture>
-  <img src="./images/interchain-shielded-pool.jpg" />
+  <img src="/images/interchain-shielded-pool.jpg" />
 </picture>
 

--- a/pages/interchain-privacy.mdx
+++ b/pages/interchain-privacy.mdx
@@ -82,7 +82,7 @@ linking different inbound transfers if the same address was used multiple times.
 Instead, Penumbra clients should automatically generate a new IBC deposit
 address for each transfer to ensure deposits are not linkable.  This is not a
 problem for transfers _within_ Penumbra, where addresses are not revealed
-anyways. For further details on the provided privacy properties, see [Privacy Features](/privacy#ibc-transfers).
+anyways. For further details on the provided privacy properties, see [Privacy Features](./privacy.mdx#ibc-transfers).
 
 #### Inspecting Addresses
 
@@ -93,7 +93,7 @@ may be useful when inspecting transactions elsewhere.
 For example, using Prax:
 
 <div style={{ display: 'flex', marginTop: '1em' }}>
-  <img src="./images/inspect-1.png" style={{ width: '33.33%' }} />
-  <img src="./images/inspect-3.png" style={{ width: '33.33%' }} />
-  <img src="./images/inspect-2.png" style={{ width: '33.33%' }} />
+  <img src="/images/inspect-1.png" style={{ width: '33.33%' }} />
+  <img src="/images/inspect-3.png" style={{ width: '33.33%' }} />
+  <img src="/images/inspect-2.png" style={{ width: '33.33%' }} />
 </div>

--- a/pages/node/pd.md
+++ b/pages/node/pd.md
@@ -4,12 +4,12 @@ This section describes how to build and run `pd`, the node implementation for
 Penumbra.  This is not necessary to use Penumbra, but promotes decentralization
 and allows deeper interactions with network data.
 
-The [Tutorial](./pd/running-node.md) section has a quickstart tutorial for setting up `pd` on a bare metal server rented from a cloud provider.
+The [Tutorial](./pd/running-node.mdx) section has a quickstart tutorial for setting up `pd` on a bare metal server rented from a cloud provider.
 
 The other pages describe running a node in detail:
 
 - [Requirements](./pd/requirements.md) describes the compute resource necessary to run a Penumbra node;
-- [Installing `pd`](./pd/install.md) describes how to install or build `pd`;
+- [Installing `pd`](./pd/install.mdx) describes how to install or build `pd`;
 - [Joining a network](./pd/join-network.md) describes how to join an existing Penumbra network;
 - [Becoming a validator](./pd/validator.md) describes how to become a validator and participate in consensus;
 - [Indexing ABCI events](./pd/validator.md) describes how to ingest events into a database for further processing or analysis;

--- a/pages/node/pd/install.mdx
+++ b/pages/node/pd/install.mdx
@@ -4,7 +4,7 @@ import { COMETBFT_VERSION } from '../../../penumbra_versions.js';
 There are many ways to configure and run Penumbra. The easiest is to download
 binaries for `pd` and `cometbft` on a Linux system. For alternatives, see
 [deployment strategies](./requirements.md#deployment-strategies).
-If you want a detailed guide, see the [tutorial on running a node](../../tutorials/running-node.md).
+If you want a detailed guide, see the [tutorial on running a node](./running-node.mdx).
 
 ## Quickstart
 Download prebuilt binaries from the [Penumbra releases page on Github](https://github.com/penumbra-zone/penumbra/releases).

--- a/pages/node/pd/join-network.md
+++ b/pages/node/pd/join-network.md
@@ -11,7 +11,7 @@ of the consensus set.
 
 ## Generating configs
 
-To join a network as a fullnode, [install the most recent version of `pd`](install.md), run
+To join a network as a fullnode, [install the most recent version of `pd`](install.mdx), run
 `pd network join` to generate configs, then use those configs to run `pd` and
 `cometbft`.
 

--- a/pages/node/pd/running-node.mdx
+++ b/pages/node/pd/running-node.mdx
@@ -102,5 +102,5 @@ The final command will display logs from the `pd` process. In a short while, you
 blocks streaming in. If not, see the [debugging steps](./debugging.md)
 to figure out what went wrong.
 
-[pcli]: ../pcli.md
+[pcli]: ../../pcli.md
 [Prax wallet]: https://chromewebstore.google.com/detail/prax-wallet/lkpmkhpnhknhmibgnmmhdhgdilepfghe

--- a/pages/pcli/governance.md
+++ b/pages/pcli/governance.md
@@ -14,7 +14,7 @@ in mind, here are some quick links:
 - [I want to submit a new proposal.](#submitting-a-proposal)
 - [I submitted a proposal and I want to withdraw it before voting concludes.](#withdrawing-a-proposal)
 - [Voting has concluded on a proposal I submitted and I want to claim my deposit.](#claiming-a-proposal-deposit)
-- [I want to contribute funds to the Community Pool.](#contributing-to-the-community-pool)
+- [I want to propose spending funds from the Community Pool.](#making-a-community-pool-spend-transaction-plan)
 
 ## Getting Proposal Information
 
@@ -108,8 +108,8 @@ from being slashed. This is usually used when a proposal has been superseded by 
 alternative.
 
 <picture>
-  <source srcset="../images/governance-dark.png" media="(prefers-color-scheme: dark)" />
-  <img src="../images/governance-light.png" />
+  <source srcset="/images/governance-dark.png" media="(prefers-color-scheme: dark)" />
+  <img src="/images/governance-light.png" />
 </picture>
 
 In the above, rounded grey boxes are actions submitted by the proposal author, rectangular colored

--- a/pages/pcli/install.md
+++ b/pages/pcli/install.md
@@ -38,7 +38,7 @@ pcli: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required 
 ```
 
 If you see that message, you must either switch to a supported platform, or else
-[build the software from source](../dev/build.md). If you need to use Windows,
+[build the software from source](../dev/build.mdx). If you need to use Windows,
 consider using [WSL].
 
 [WSL]: https://learn.microsoft.com/en-us/windows/wsl/install

--- a/pages/quickstart.mdx
+++ b/pages/quickstart.mdx
@@ -8,7 +8,7 @@ import Disconnect from "@/components/Disconnect";
 
 # Getting Started
 
-This quick start guide will help you get started with Penumbra using a web-based wallet, and walk you through each basic feature. For more detailed walkthroughs of each feature, see the [web](/web) section.
+This quick start guide will help you get started with Penumbra using a web-based wallet, and walk you through each basic feature. For more detailed walkthroughs of each feature, see the [web](./web.mdx) section.
 
 <Steps>
 

--- a/pages/relayers.md
+++ b/pages/relayers.md
@@ -82,7 +82,7 @@ You'll need to communicate the channels that you maintain to the community. How 
 
 ## Performing upgrades
 
-When a [Penumbra chain upgrade](./node/pd/chain-upgrade.md) is performed, relayer operators must [configure an archive node](./node/pd/indexing-events.md#running-an-archive-node)
+When a [Penumbra chain upgrade](./node/pd/chain-upgrade.mdx) is performed, relayer operators must [configure an archive node](./node/pd/indexing-events.md#running-an-archive-node)
 on the pre-upgrade version of `pd`, and use that archive node, as well as an upgraded Penumbra node, to bridge the upgrade boundary via the relayer.
 See the [genesis-restart](https://hermes.informal.systems/advanced/troubleshooting/genesis-restart.html?highlight=genesis%20restart#updating-a-client-after-a-genesis-restart-without-ibc-upgrade-proposal) functionality in the Hermes docs.
 In order to perform this step, you'll need the following information:

--- a/pages/staking.mdx
+++ b/pages/staking.mdx
@@ -25,7 +25,7 @@ To prevent validators from escaping slashing penalties by quickly withdrawing th
 When a delegator undelegates, their delegation tokens first convert to **unbonding tokens**. These unbonding tokens are tied to the validator identity, such that they remain exposed to slashing penalties if validator misbehavior occurs. After the unbonding delay, the unbonding tokens can finally be converted back to staking tokens, taking into account the earned staking rewards using that validator's exchange rate.
 
 <picture>
-  <img src="./images/staking-token-flow.png" />
+  <img src="/images/staking-token-flow.png" />
 </picture>
 
 The unbonding delay is currently set to 120,960 blocks, or approximately 7 days on mainnet (set via the `unbondingDelay` chain parameter).

--- a/pages/web.mdx
+++ b/pages/web.mdx
@@ -4,7 +4,7 @@ import { Callout } from 'nextra/components'
 
 This section of the guide describes in detail how to use Penumbra from a web browser.
 
-<Callout type="info" emoji="ℹ️">Get up and running quickly with [our interactive guide](/quickstart) to basic Penumbra actions!</Callout>
+<Callout type="info" emoji="ℹ️">Get up and running quickly with [our interactive guide](./quickstart.mdx) to basic Penumbra actions!</Callout>
 
 For more detailed information on each of the actions, see the following pages:
 

--- a/pages/web/balances.mdx
+++ b/pages/web/balances.mdx
@@ -18,7 +18,7 @@ Prax Wallet displays your balance per account. Simply click the Prax icon in the
 
 The balances are displayed by asset type. For example, here we see the balance of the main account includes Penumbra's staking token UM, as well as ATOM.
 
-<Callout type="info" emoji="ℹ️">Recall that in Penumbra, your wallet has multiple **Accounts**, and each account has many **Shielded Addresses**. See [Interchain Privacy](/interchain-privacy) for more details.</Callout>
+<Callout type="info" emoji="ℹ️">Recall that in Penumbra, your wallet has multiple **Accounts**, and each account has many **Shielded Addresses**. See [Interchain Privacy](../interchain-privacy.mdx) for more details.</Callout>
 
 By clicking the arrow to the right, you can view the balances and default addresses, of the other accounts in your wallet:
 

--- a/pages/web/ibc-transfers.mdx
+++ b/pages/web/ibc-transfers.mdx
@@ -6,11 +6,11 @@ In this section, we'll describe how to get your funds into Penumbra. This is don
 
 As soon as you transfer into Penumbra, your funds are shielded. All other transfers you do within the Penumbra zone are also shielded.
 
-<Callout type="info" emoji="ℹ️">When you transfer funds using IBC, a randomized IBC deposit address is generated for your privacy - to prevent linking different inbound transfers. Read more about this [here](/web/balances#ibc-deposit-addresses-in-prax-wallet).</Callout>
+<Callout type="info" emoji="ℹ️">When you transfer funds using IBC, a randomized IBC deposit address is generated for your privacy - to prevent linking different inbound transfers. Read more about this [here](./balances.mdx#ibc-deposit-addresses-in-prax-wallet).</Callout>
 
 ## Skip App
 
-An easy way to transfer funds into Penumbra is to use Skip. You can visit [their app directly](https://go.skip.build), you can use the Skip widget on our [quickstart page](/quickstart), or you can use the [Skip integration in the default frontend](https://app.penumbra.zone/#/deposit/skip).
+An easy way to transfer funds into Penumbra is to use Skip. You can visit [their app directly](https://go.skip.build), you can use the Skip widget on our [quickstart page](../quickstart.mdx), or you can use the [Skip integration in the default frontend](https://app.penumbra.zone/#/deposit/skip).
 
 Either way, you'll see an interface like this:
 

--- a/pages/web/send.mdx
+++ b/pages/web/send.mdx
@@ -1,6 +1,6 @@
 # Sending Funds
 
-Use the [Send](https://app.penumbra.zone/#/send) page on the frontend to send funds to another Penumbra address. This can be done to send funds between your accounts, or to send to another person's wallet. To send funds out of Penumbra, see the [Withdraw](/web/withdraw) page.
+Use the [Send](https://app.penumbra.zone/#/send) page on the frontend to send funds to another Penumbra address. This can be done to send funds between your accounts, or to send to another person's wallet. To send funds out of Penumbra, see the [Withdraw](./withdraw.mdx) page.
 
 First, you select the asset you wish to send, and the destination address.
 

--- a/pages/web/withdraw.mdx
+++ b/pages/web/withdraw.mdx
@@ -10,7 +10,10 @@ Be aware that once you leave the Penumbra zone, your funds are no longer shielde
 
 To withdraw funds using the default frontend, go to the [Withdraw](https://app.penumbra.zone/#/withdraw) page (via **Shield Funds** and then clicking the **Withdraw** tab).
 
-![Withdraw unfilled](/images/withdraw-unfilled.png)
+<div className="flex justify-center">
+  ![Withdraw Unfilled](/images/withdraw-unfilled.png)
+</div>
+
 
 From there, you select:
 


### PR DESCRIPTION
Adds `markdown-link-check` to CI, and updates all URLs reported as failing. There are a few exceptions, added to the ignore list by regex. For the most part, image URLs are substituted during linting so that the relpath to the file can be found.

In several locations, I updated the nextra-specific `/foo` URLs to be a more Markdown-compliant `./foo.md`. Not sure whether this will have an adverse affect on site performance, but I suggest it's a worthwhile change to prevent broken links from plaguing the docs.