### PR TITLE
refactor: de-prioritize nix docs for dev env

### DIFF
--- a/pages/dev/_meta.json
+++ b/pages/dev/_meta.json
@@ -1,5 +1,5 @@
 {
-  "dev-env": "Developer environment",
+  "build": "Compiling from source",
   "devnet-quickstart": "Devnet quickstart",
   "testnet": "Testnet",
   "sql": "Working with SQLite",
@@ -9,5 +9,5 @@
   "parameter_setup": "Zero-knowledge proofs",
   "rpc": "RPC access",
   "ibc": "Testing IBC",
-  "build": "Compiling from source"
+  "dev-env": "Developer environment"
 }

--- a/pages/dev/build.mdx
+++ b/pages/dev/build.mdx
@@ -8,8 +8,9 @@ We don't support building on Windows. If you need to use Windows,
 consider using [WSL] instead.
 
 This page aims to describe the steps necessary to work on Penumbra when
-settings up the build environment manually, without using [Nix].
-If you want an easy-to-use setup, see the docs on [developer environments](./dev-env.mdx).
+setting up the build environment manually.
+If you want an easy-to-use setup, see the docs on [developer environments](./dev-env.mdx),
+which uses [Nix].
 
 ### Installing the Rust toolchain
 
@@ -24,39 +25,32 @@ to build the project from source.
 
 ### Installing build prerequisites
 
-#### Linux
+You must install some additional packages in order to build the Penumbra software,
+depending on your distribution.
 
-You may need to install some additional packages in order to build `pcli`,
-depending on your distribution. For a bare-bones Ubuntu installation, you can
-run:
+import { Tabs } from 'nextra/components';
 
-```bash
-sudo apt-get install build-essential pkg-config libssl-dev clang git-lfs
-```
+<Tabs items={['macOS', 'Debian', 'Fedora']}>
+  <Tabs.Tab>
+  ```shell
+  xcode-select --install
+  brew install git-lfs
+  git lfs install
+  ```
+  </Tabs.Tab>
 
-For a minimal Fedora/CentOS/RHEL image, you can run:
+  <Tabs.Tab>
+  ```shell
+  sudo apt-get install build-essential pkg-config libssl-dev clang git-lfs
+  ```
+  </Tabs.Tab>
 
-```bash
-sudo dnf install openssl-devel clang git cargo rustfmt git-lfs
-```
-
-#### macOS
-
-You may need to install the command-line developer tools if you have never done
-so:
-```bash
-xcode-select --install
-```
-
-You'll also need to install Git LFS, which you can do [via Homebrew](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage?platform=mac):
-
-```bash
-brew install git-lfs
-```
-
-### Making sure that `git-lfs` is installed
-
-Running `git lfs install` will make sure that git-lfs is correctly installed on your machine.
+  <Tabs.Tab>
+  ```shell
+  sudo dnf install openssl-devel clang git cargo rustfmt git-lfs
+  ```
+  </Tabs.Tab>
+</Tabs>
 
 ### Cloning the repository
 

--- a/pages/dev/dev-env.mdx
+++ b/pages/dev/dev-env.mdx
@@ -15,7 +15,9 @@ import { Tabs } from 'nextra/components';
 <Tabs items={['macOS', 'Debian', 'Fedora']}>
   <Tabs.Tab>
   ```shell
+  xcode-select --install
   brew install git-lfs
+  git lfs install
   ```
   </Tabs.Tab>
 


### PR DESCRIPTION
The first impression in the developer docs is now an explanation of building the repo from source, after manually installing dependencies. There's still a link-out to the escape hatch of using nix, for those who want the automated setup.

Closes #46.