### PR TITLE
Update build.mdx instructions, Ubuntu 25.04

### DIFF
--- a/pages/dev/build.mdx
+++ b/pages/dev/build.mdx
@@ -41,7 +41,7 @@ import { Tabs } from 'nextra/components';
 
   <Tabs.Tab>
   ```shell
-  sudo apt-get install build-essential pkg-config libssl-dev clang git-lfs
+  sudo apt-get install build-essential pkg-config libssl-dev clang git-lfs libdbus-1-dev libusb-1.0-0-dev
   ```
   </Tabs.Tab>
 


### PR DESCRIPTION
Running Ubuntu 25.04, successful compile needed:

`sudo apt make libdbus-1-dev libusb-1.0-0-dev`