### PR TITLE
docs: sql abci event examples

### DIFF
--- a/pages/dev/abci-events.md
+++ b/pages/dev/abci-events.md
@@ -5,6 +5,7 @@ configure access to a [pindexer] database.
 More advanced use cases may require a custom implementation of the underlying
 [cometindex] logic that powers `pindexer`.
 
+## pindexer
 Below are some examples to orient a developer to the structure of a `pindexer` database,
 which is intended to be more ergonomic for application development than the default
 CometBFT ABCI event schema.
@@ -41,6 +42,29 @@ LEFT JOIN LATERAL (
 <!--
 TODO: add more examples plucked from real-world use cases
 -->
+
+## cometindex
+
+When writing your own [cometindex] implementation, you'll need to reference a source
+CometBFT database and query it for information. Here are some example for how to do that.
+
+### View all events in database
+
+```sql
+SELECT type, COUNT(*) as count
+FROM events
+GROUP BY type
+ORDER BY count DESC;
+```
+
+### View all non-Penumbra-specific events
+
+```sql
+SELECT type, COUNT(*) as count
+FROM events WHERE type NOT LIKE 'penumbra.core.%'
+GROUP BY type
+ORDER BY count DESC;
+```
 
 [pindexer]: ../event-indexing/pindexer.md
 [cometindex]: https://github.com/penumbra-zone/penumbra/tree/main/crates/util/cometindex


### PR DESCRIPTION
Adds a few illustrative queries, to encourage a developer in exploring the db for the first time.

Follow-up to #73 & #74.